### PR TITLE
Application Version: 2.1.0, Backend Version: 6.1.0

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbs-electron",
   "productName": "Keyboard Sounds",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "https://keyboardsounds.net/",
   "main": ".webpack/main",
   "repository": {

--- a/application/src/api/core.js
+++ b/application/src/api/core.js
@@ -15,7 +15,7 @@ import Mixpanel from 'mixpanel';
 const store = new Store();
 
 const MinimumPythonVersion = '3.8.0';
-const MinimumPythonPackageVersion = '6.0.9';
+const MinimumPythonPackageVersion = '6.1.0';
 
 const ErrPythonVersionUnknown = 'Failed to parse python version';
 const ErrPythonMissing = 'Python is not installed';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keyboardsounds"
-version = "6.0.9"
+version = "6.1.0"
 authors = [
   { name="Nathan Fiscaletti", email="nate.fiscaletti@gmail.com" },
 ]
@@ -20,7 +20,8 @@ dependencies=[
   "pyyaml==6.0.2",
   "setuptools==75.3.0",
   "requests==2.32.3",
-  "pydub==0.25.1"
+  "pydub==0.25.1",
+  "audioop-lts==0.2.2; python_version>='3.13'"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML==6.0.2
 Requests==2.32.3
 setuptools==75.3.0
 pydub==0.25.1
+audioop-lts==0.2.2; python_version>='3.13'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="keyboardsounds",
-    version="6.0.9",
+    version="6.1.0",
     description="Adds the ability to play sounds while typing on any system.",
     author="Nathan Fiscaletti",
     author_email="nate.fiscaletti@gmail.com",
@@ -16,6 +16,7 @@ setup(
         "setuptools==75.3.0",
         "requests==2.32.3",
         "pydub==0.25.1",
+        "audioop-lts==0.2.2; python_version>='3.13'",
     ],
     package_data={
         "keyboardsounds": [


### PR DESCRIPTION
Fixed issue with audioop package not being installed in python versions > 3.13 due to PEP 594